### PR TITLE
Request Option API

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,13 +22,20 @@ type client struct {
 
 func New(opts ...Option) Gore {
 	c := &client{}
-	for _, opt := range opts {
-		opt(c)
-	}
+	resolveOptions(c, opts...)
 	c.client = &http.Client{
 		Timeout: c.timeout,
 	}
+
 	return c
+}
+
+func resolveOptions(c *client, opts ...Option) {
+	for _, opt := range opts {
+		if opt != nil {
+			opt(c)
+		}
+	}
 }
 
 func (c client) validateURL(fromUrl string) error {
@@ -82,24 +89,34 @@ func (c client) req(reqUrl string, method string, header http.Header, body []byt
 	return &Response{resp}, nil
 }
 
-func (c client) Get(reqUrl string, header http.Header) (*Response, error) {
-	return c.req(reqUrl, http.MethodGet, header, nil)
+func (c client) Get(reqUrl string, opts ...Option) (*Response, error) {
+	cCopy := c
+	resolveOptions(&cCopy, opts...)
+	return c.req(reqUrl, http.MethodGet, cCopy.baseHeader, nil)
 }
 
-func (c client) Post(reqUrl string, header http.Header, body []byte) (*Response, error) {
-	return c.req(reqUrl, http.MethodPost, header, body)
+func (c client) Post(reqUrl string, body []byte, opts ...Option) (*Response, error) {
+	cCopy := c
+	resolveOptions(&cCopy, opts...)
+	return c.req(reqUrl, http.MethodPost, cCopy.baseHeader, body)
 }
 
-func (c client) Put(reqUrl string, header http.Header, body []byte) (*Response, error) {
-	return c.req(reqUrl, http.MethodPut, header, body)
+func (c client) Put(reqUrl string, body []byte, opts ...Option) (*Response, error) {
+	cCopy := c
+	resolveOptions(&cCopy, opts...)
+	return c.req(reqUrl, http.MethodPut, cCopy.baseHeader, body)
 }
 
-func (c client) Patch(reqUrl string, header http.Header, body []byte) (*Response, error) {
-	return c.req(reqUrl, http.MethodPatch, header, body)
+func (c client) Patch(reqUrl string, body []byte, opts ...Option) (*Response, error) {
+	cCopy := c
+	resolveOptions(&cCopy, opts...)
+	return c.req(reqUrl, http.MethodPatch, cCopy.baseHeader, body)
 }
 
-func (c client) Delete(reqUrl string, header http.Header) (*Response, error) {
-	return c.req(reqUrl, http.MethodDelete, header, nil)
+func (c client) Delete(reqUrl string, opts ...Option) (*Response, error) {
+	cCopy := c
+	resolveOptions(&cCopy, opts...)
+	return c.req(reqUrl, http.MethodDelete, cCopy.baseHeader, nil)
 }
 
 func (c client) Do(req *http.Request) (*Response, error) {

--- a/client.go
+++ b/client.go
@@ -10,10 +10,11 @@ import (
 )
 
 type client struct {
-	client     *http.Client
-	timeout    time.Duration
-	baseURL    string
-	baseHeader http.Header
+	client        *http.Client
+	timeout       time.Duration
+	baseURL       string
+	baseHeader    http.Header
+	temporaryBody []byte
 
 	errorHandler         ErrorHandler
 	beforeRequestHandler BeforeRequestHandler
@@ -95,22 +96,22 @@ func (c client) Get(reqUrl string, opts ...Option) (*Response, error) {
 	return c.req(reqUrl, http.MethodGet, cCopy.baseHeader, nil)
 }
 
-func (c client) Post(reqUrl string, body []byte, opts ...Option) (*Response, error) {
+func (c client) Post(reqUrl string, opts ...Option) (*Response, error) {
 	cCopy := c
 	resolveOptions(&cCopy, opts...)
-	return c.req(reqUrl, http.MethodPost, cCopy.baseHeader, body)
+	return c.req(reqUrl, http.MethodPost, cCopy.baseHeader, cCopy.temporaryBody)
 }
 
-func (c client) Put(reqUrl string, body []byte, opts ...Option) (*Response, error) {
+func (c client) Put(reqUrl string, opts ...Option) (*Response, error) {
 	cCopy := c
 	resolveOptions(&cCopy, opts...)
-	return c.req(reqUrl, http.MethodPut, cCopy.baseHeader, body)
+	return c.req(reqUrl, http.MethodPut, cCopy.baseHeader, cCopy.temporaryBody)
 }
 
-func (c client) Patch(reqUrl string, body []byte, opts ...Option) (*Response, error) {
+func (c client) Patch(reqUrl string, opts ...Option) (*Response, error) {
 	cCopy := c
 	resolveOptions(&cCopy, opts...)
-	return c.req(reqUrl, http.MethodPatch, cCopy.baseHeader, body)
+	return c.req(reqUrl, http.MethodPatch, cCopy.baseHeader, cCopy.temporaryBody)
 }
 
 func (c client) Delete(reqUrl string, opts ...Option) (*Response, error) {

--- a/example/instance/main.go
+++ b/example/instance/main.go
@@ -13,7 +13,11 @@ func panicOnError(err error) {
 }
 
 func main() {
-	resp, err := goreq.Get("https://my-json-server.typicode.com/hadihammurabi/flutter-webservice/contacts")
+	g := goreq.New(
+		goreq.WithBaseURL("https://my-json-server.typicode.com/hadihammurabi/flutter-webservice"),
+	)
+
+	resp, err := g.Get("/contacts")
 	panicOnError(err)
 	defer resp.Body.Close()
 

--- a/gore.go
+++ b/gore.go
@@ -6,9 +6,9 @@ import (
 
 type Gore interface {
 	Get(url string, opts ...Option) (*Response, error)
-	Post(url string, body []byte, opts ...Option) (*Response, error)
-	Put(url string, body []byte, opts ...Option) (*Response, error)
-	Patch(url string, body []byte, opts ...Option) (*Response, error)
+	Post(url string, opts ...Option) (*Response, error)
+	Put(url string, opts ...Option) (*Response, error)
+	Patch(url string, opts ...Option) (*Response, error)
 	Delete(url string, opts ...Option) (*Response, error)
 	Do(*http.Request) (*Response, error)
 }

--- a/gore.go
+++ b/gore.go
@@ -5,11 +5,11 @@ import (
 )
 
 type Gore interface {
-	Get(url string, header http.Header) (*Response, error)
-	Post(url string, header http.Header, body []byte) (*Response, error)
-	Put(url string, header http.Header, body []byte) (*Response, error)
-	Patch(url string, header http.Header, body []byte) (*Response, error)
-	Delete(url string, header http.Header) (*Response, error)
+	Get(url string, opts ...Option) (*Response, error)
+	Post(url string, body []byte, opts ...Option) (*Response, error)
+	Put(url string, body []byte, opts ...Option) (*Response, error)
+	Patch(url string, body []byte, opts ...Option) (*Response, error)
+	Delete(url string, opts ...Option) (*Response, error)
 	Do(*http.Request) (*Response, error)
 }
 

--- a/helper.go
+++ b/helper.go
@@ -8,18 +8,18 @@ func Get(url string, opts ...Option) (*Response, error) {
 	return New(opts...).Get(url)
 }
 
-func Post(url string, header http.Header, body []byte, opts ...Option) (*Response, error) {
-	return New(opts...).Post(url, body, opts...)
+func Post(url string, header http.Header, opts ...Option) (*Response, error) {
+	return New(opts...).Post(url, opts...)
 }
 
-func Put(url string, header http.Header, body []byte, opts ...Option) (*Response, error) {
-	return New(opts...).Put(url, body, opts...)
+func Put(url string, header http.Header, opts ...Option) (*Response, error) {
+	return New(opts...).Put(url, opts...)
 }
 
-func Patch(url string, header http.Header, body []byte, opts ...Option) (*Response, error) {
-	return New(opts...).Patch(url, body, opts...)
+func Patch(url string, header http.Header, opts ...Option) (*Response, error) {
+	return New(opts...).Patch(url, opts...)
 }
 
-func Delete(url string, header http.Header, body []byte, opts ...Option) (*Response, error) {
+func Delete(url string, header http.Header, opts ...Option) (*Response, error) {
 	return New(opts...).Delete(url, opts...)
 }

--- a/helper.go
+++ b/helper.go
@@ -4,22 +4,22 @@ import (
 	"net/http"
 )
 
-func Get(url string, header http.Header, opts ...Option) (*Response, error) {
-	return New(opts...).Get(url, header)
+func Get(url string, opts ...Option) (*Response, error) {
+	return New(opts...).Get(url)
 }
 
 func Post(url string, header http.Header, body []byte, opts ...Option) (*Response, error) {
-	return New(opts...).Post(url, header, body)
+	return New(opts...).Post(url, body, opts...)
 }
 
 func Put(url string, header http.Header, body []byte, opts ...Option) (*Response, error) {
-	return New(opts...).Put(url, header, body)
+	return New(opts...).Put(url, body, opts...)
 }
 
 func Patch(url string, header http.Header, body []byte, opts ...Option) (*Response, error) {
-	return New(opts...).Patch(url, header, body)
+	return New(opts...).Patch(url, body, opts...)
 }
 
 func Delete(url string, header http.Header, body []byte, opts ...Option) (*Response, error) {
-	return New(opts...).Delete(url, header)
+	return New(opts...).Delete(url, opts...)
 }

--- a/helper.go
+++ b/helper.go
@@ -1,25 +1,21 @@
 package goreq
 
-import (
-	"net/http"
-)
-
 func Get(url string, opts ...Option) (*Response, error) {
 	return New(opts...).Get(url)
 }
 
-func Post(url string, header http.Header, opts ...Option) (*Response, error) {
+func Post(url string, opts ...Option) (*Response, error) {
 	return New(opts...).Post(url, opts...)
 }
 
-func Put(url string, header http.Header, opts ...Option) (*Response, error) {
+func Put(url string, opts ...Option) (*Response, error) {
 	return New(opts...).Put(url, opts...)
 }
 
-func Patch(url string, header http.Header, opts ...Option) (*Response, error) {
+func Patch(url string, opts ...Option) (*Response, error) {
 	return New(opts...).Patch(url, opts...)
 }
 
-func Delete(url string, header http.Header, opts ...Option) (*Response, error) {
+func Delete(url string, opts ...Option) (*Response, error) {
 	return New(opts...).Delete(url, opts...)
 }

--- a/option.go
+++ b/option.go
@@ -39,6 +39,12 @@ func WithHeader(header http.Header) Option {
 	}
 }
 
+func WithBody(body []byte) Option {
+	return func(c *client) {
+		c.temporaryBody = body
+	}
+}
+
 func WithErrorHandler(handler ErrorHandler) Option {
 	return func(c *client) {
 		c.errorHandler = handler

--- a/option.go
+++ b/option.go
@@ -25,6 +25,20 @@ func WithBaseHeader(header http.Header) Option {
 	}
 }
 
+func WithHeader(header http.Header) Option {
+	return func(c *client) {
+		newHeader := make(http.Header)
+		for key, val := range c.baseHeader {
+			newHeader[key] = val
+		}
+		for key, val := range header {
+			newHeader[key] = val
+		}
+
+		c.baseHeader = newHeader
+	}
+}
+
 func WithErrorHandler(handler ErrorHandler) Option {
 	return func(c *client) {
 		c.errorHandler = handler


### PR DESCRIPTION
Every request focus on URL.
If there any headers or body, it can insert using request options.

Example 1 - simple request:
```go
goreq.Get("https://my-json-server.typicode.com/hadihammurabi/flutter-webservice/contacts")
```

Example 2 - with header and body:
```go
goreq.Post(
  "https://my-json-server.typicode.com/hadihammurabi/flutter-webservice/contacts",
  goreq.WithHeader(http.Header{
	"x-token": []string{"dljasdljwadjiowjd"},
  }),
  goreq.WithBody([]byte(`
	{"username": "alexunder", "password": "12345"}
  `)),
)
```

Fixes #1 